### PR TITLE
BUGFIX: Fixed crash when deleting/archiving an album

### DIFF
--- a/src/Models/PhotoAlbum.php
+++ b/src/Models/PhotoAlbum.php
@@ -7,6 +7,7 @@ use AndrewHoule\PhotoGallery\Pages\PhotoGallery;
 use AndrewHoule\PhotoGallery\Traits\CMSPermissionProvider;
 // use Colymba\BulkUpload\BulkUploader;
 use SilverStripe\AssetAdmin\Forms\UploadField;
+use SilverStripe\Assets\Folder;
 use SilverStripe\Assets\Image;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridField;
@@ -214,7 +215,7 @@ class PhotoAlbum extends DataObject
         }
 
         // Delete the album folder
-        $albumfolder = $this->AlbumFolder();
+        $albumfolder = $this->AlbumFolderName();
         $folder = Folder::get()->filter('Name', $albumfolder)->first();
         if ($folder) {
             $folder->delete();


### PR DESCRIPTION
Deleting a photo album can cause 2 crashes, first for an undefined method call, and second because the use statement was not present for ``SilverStripe\Assets\Folder``, this pull request addresses both issues.